### PR TITLE
New endpoint and errors list updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,23 @@ public async listCertificates(options?: ListCertificateOptions): Promise<Certifi
 public async verificationStatus(id: string): Promise<VerificationStatus>
 public async resendVerification(id: string): Promise<boolean>
 public async cancelCertificate(id: string): Promise<boolean>
-public async deleteCertificate(id: string): Promise<boolean>
+public async revokeCertificate(id: string): Promise<boolean>
 public async validateCSR(csr: string): Promise<CertificateSigningRequestValidationResult>
 public generateKeyPair(bits = 2048): KeyPair
 public generateCSR(keypair: KeyPair, options: CertificateSigningRequestOptions): string
+```
+
+### Error Return
+
+If an error occurs in your request, we will trigger a throw error detailing the error name, error code, error type and error status code through an object as you can see below:
+
+```json
+{
+    "message": "An error has occurred",
+    "code": "000",
+    "type": "error_example",
+    "status" : 400
+}
 ```
 
 ### Types

--- a/dist/lib/errors.js
+++ b/dist/lib/errors.js
@@ -7,6 +7,11 @@ exports.ZeroSSLErrorMap = {
         type: 'domain_control_validation_failed',
         message: ''
     },
+    2835: {
+        code: 2835,
+        type: 'certificate_cannot_be_deleted',
+        message: 'This endpoint has been removed. There is no valid reason to delete a certificate - instead they should be expired, revoked or cancelled'
+    },
     101: {
         code: 101,
         type: 'invalid_access_key',
@@ -16,6 +21,16 @@ exports.ZeroSSLErrorMap = {
         code: 103,
         type: 'invalid_api_function',
         message: 'User has provided an invalid API function.'
+    },
+    110: {
+        code: 110,
+        type: 'invalid_request_body',
+        message: 'The body of your request was wrong. Please check your request arguments.'
+    },
+    111: {
+        code: 111,
+        type: 'internal_server_error',
+        message: 'Something went wrong. If the problem persists please contact our support team (support@zerossl.com).'
     },
     2800: {
         code: 2800,
@@ -132,6 +147,11 @@ exports.ZeroSSLErrorMap = {
         type: 'duplicate_certificates_found',
         message: 'Domain can no longer be protected using Free Plan, upgrade to Basic Plan required.'
     },
+    2841: {
+        code: 2841,
+        type: 'certificate_creation_locked_unpaid_invoices',
+        message: 'Your account has been temporarily suspended due to unpaid invoices. Please pay your open invoices in order to unlock this endpoint.'
+    },
     2822: {
         code: 2822,
         type: 'failed_showing_certificate',
@@ -140,7 +160,7 @@ exports.ZeroSSLErrorMap = {
     2823: {
         code: 2823,
         type: 'failed_validating_certificate',
-        message: 'Domain verification failed and must be retried.'
+        message: 'Domain verification failed and must be retried. (restricted TLD, domain name is too long or CSR compromised)'
     },
     2824: {
         code: 2824,
@@ -192,6 +212,16 @@ exports.ZeroSSLErrorMap = {
         type: 'certificate_not_issued',
         message: 'The given certificate has not been issued yet.'
     },
+    2860: {
+        code: 2860,
+        type: 'certificate_not_downloadable',
+        message: 'The certificate can currently not be downloaded.'
+    },
+    2906: {
+        code: 2906,
+        type: 'revocation_failed',
+        message: 'The certificate can not be revoked currently, please try again later. If the problem persists - especially in urgent cases like key compromise - please contact our support team (support@zerossl.com).'
+    },
     2833: {
         code: 2833,
         type: 'certificate_cannot_be_cancelled',
@@ -201,16 +231,6 @@ exports.ZeroSSLErrorMap = {
         code: 2834,
         type: 'failed_cancelling_certificate',
         message: 'Internal error cancelling certificate. Try again or contact support.'
-    },
-    2835: {
-        code: 2835,
-        type: 'certificate_cannot_be_deleted',
-        message: 'The given certificate cannot be deleted due to its status.'
-    },
-    2836: {
-        code: 2836,
-        type: 'failed_deleting_certificate',
-        message: 'Internal error deleting certificate. Try again or contact support.'
     },
     2837: {
         code: 2837,

--- a/dist/lib/index.js
+++ b/dist/lib/index.js
@@ -1,7 +1,11 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];

--- a/dist/lib/zerossl.d.ts
+++ b/dist/lib/zerossl.d.ts
@@ -12,7 +12,7 @@ export declare class ZeroSSL {
     verificationStatus(id: string): Promise<VerificationStatus>;
     resendVerification(id: string): Promise<boolean>;
     cancelCertificate(id: string): Promise<boolean>;
-    deleteCertificate(id: string): Promise<boolean>;
+    revokeCertificate(id: string): Promise<boolean>;
     validateCSR(csr: string): Promise<CertificateSigningRequestValidationResult>;
     generateKeyPair(bits?: number): KeyPair;
     generateCSR(keypair: KeyPair, options: CertificateSigningRequestOptions): string;

--- a/dist/lib/zerossl.js
+++ b/dist/lib/zerossl.js
@@ -75,7 +75,12 @@ var ZeroSSL = (function () {
                         if (response.status !== 200 || response.body.success === false) {
                             errorCode = response.body.error.code || 0;
                             error = errors_1.ZeroSSLErrorMap[errorCode];
-                            throw new Error("".concat(error.code, " (").concat(error.type, ") ").concat(error.message));
+                            throw ({
+                                message: error.message,
+                                code: error.code,
+                                type: error.type,
+                                status: response.status
+                            });
                         }
                         return [2, response];
                 }
@@ -242,15 +247,15 @@ var ZeroSSL = (function () {
             });
         });
     };
-    ZeroSSL.prototype.deleteCertificate = function (id) {
+    ZeroSSL.prototype.revokeCertificate = function (id) {
         return __awaiter(this, void 0, void 0, function () {
             var qs, url, postFn, result;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
                         qs = this.queryString({ access_key: this.options.accessKey });
-                        url = "".concat(this.options.apiUrl, "/certificates/").concat(id, "?").concat(qs);
-                        postFn = superagent_1["default"]["delete"](url);
+                        url = "".concat(this.options.apiUrl, "/certificates/").concat(id, "/revoke?").concat(qs);
+                        postFn = superagent_1["default"].post(url);
                         return [4, this.performRequest(postFn)];
                     case 1:
                         result = _a.sent();

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -66,6 +66,13 @@ export const ZeroSSLErrorMap: { [key: number]: ZeroSSLError } = {
     message: ''
   },
 
+  // 2835 is a new error when trying to use delete endpoint (currently removed)
+  2835: {
+    code: 2835,
+    type: 'certificate_cannot_be_deleted',
+    message: 'This endpoint has been removed. There is no valid reason to delete a certificate - instead they should be expired, revoked or cancelled'
+  },
+
   //
   // Errors - General
   //

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -79,6 +79,16 @@ export const ZeroSSLErrorMap: { [key: number]: ZeroSSLError } = {
     type: 'invalid_api_function',
     message: 'User has provided an invalid API function.'
   },
+  110: {
+    code: 110,
+    type: 'invalid_request_body',
+    message: 'The body of your request was wrong. Please check your request arguments.'
+  },
+  111: {
+    code: 111,
+    type: 'internal_server_error',
+    message: 'Something went wrong. If the problem persists please contact our support team (support@zerossl.com).'
+  },
   2800: {
     code: 2800,
     type: 'incorrect_request_type',
@@ -198,6 +208,11 @@ export const ZeroSSLErrorMap: { [key: number]: ZeroSSLError } = {
     type: 'duplicate_certificates_found',
     message: 'Domain can no longer be protected using Free Plan, upgrade to Basic Plan required.'
   },
+  2841: {
+    code: 2841,
+    type: 'certificate_creation_locked_unpaid_invoices',
+    message: 'Your account has been temporarily suspended due to unpaid invoices. Please pay your open invoices in order to unlock this endpoint.'
+  },
 
   //
   // Errors - Verify Domains
@@ -210,7 +225,7 @@ export const ZeroSSLErrorMap: { [key: number]: ZeroSSLError } = {
   2823: {
     code: 2823,
     type: 'failed_validating_certificate',
-    message: 'Domain verification failed and must be retried.'
+    message: 'Domain verification failed and must be retried. (restricted TLD, domain name is too long or CSR compromised)'
   },
   2824: {
     code: 2824,
@@ -266,6 +281,20 @@ export const ZeroSSLErrorMap: { [key: number]: ZeroSSLError } = {
     type: 'certificate_not_issued',
     message: 'The given certificate has not been issued yet.'
   },
+  2860: {
+    code: 2860,
+    type: 'certificate_not_downloadable',
+    message: 'The certificate can currently not be downloaded.'
+  },
+
+  //
+  // Errors - Revoke Certiticate
+  //
+  2906: {
+    code: 2906,
+    type: 'revocation_failed',
+    message: 'The certificate can not be revoked currently, please try again later. If the problem persists - especially in urgent cases like key compromise - please contact our support team (support@zerossl.com).'
+  },
 
   //
   // Errors - Cancel Certiticate
@@ -279,20 +308,6 @@ export const ZeroSSLErrorMap: { [key: number]: ZeroSSLError } = {
     code: 2834,
     type: 'failed_cancelling_certificate',
     message: 'Internal error cancelling certificate. Try again or contact support.'
-  },
-
-  //
-  // Errors - Delete Certiticate
-  //
-  2835: {
-    code: 2835,
-    type: 'certificate_cannot_be_deleted',
-    message: 'The given certificate cannot be deleted due to its status.'
-  },
-  2836: {
-    code: 2836,
-    type: 'failed_deleting_certificate',
-    message: 'Internal error deleting certificate. Try again or contact support.'
   },
 
   //

--- a/lib/zerossl.ts
+++ b/lib/zerossl.ts
@@ -45,9 +45,9 @@ export class ZeroSSL {
         message: error.message,
         code: error.code,
         type: error.type,
-        status: response.status,
+        status: response.status
       })
-      
+
     }
     return response
   }

--- a/lib/zerossl.ts
+++ b/lib/zerossl.ts
@@ -40,7 +40,14 @@ export class ZeroSSL {
     if (response.status !== 200 || response.body.success === false) {
       const errorCode = response.body.error.code || 0
       const error = ZeroSSLErrorMap[errorCode]
-      throw new Error(`${error.code} (${error.type}) ${error.message}`)
+
+      throw ({
+        message: error.message,
+        code: error.code,
+        type: error.type,
+        status: response.status,
+      })
+      
     }
     return response
   }

--- a/lib/zerossl.ts
+++ b/lib/zerossl.ts
@@ -148,6 +148,16 @@ export class ZeroSSL {
     return result.body.success === 1
   }
 
+  // Revoke Certificate
+  public async revokeCertificate(id: string): Promise<boolean> {
+    const qs = this.queryString({ access_key: this.options.accessKey })
+    const url = `${this.options.apiUrl}/certificates/${id}/revoke?${qs}`
+    const postFn = superagent.post(url)
+    const result = await this.performRequest(postFn)
+
+    return result.body.success === 1
+  }
+
   // Validate Certificate Signing Request
   public async validateCSR(csr: string): Promise<CertificateSigningRequestValidationResult> {
     const qs = this.queryString({ access_key: this.options.accessKey })

--- a/lib/zerossl.ts
+++ b/lib/zerossl.ts
@@ -148,16 +148,6 @@ export class ZeroSSL {
     return result.body.success === 1
   }
 
-  // Delete Certificate
-  public async deleteCertificate(id: string): Promise<boolean> {
-    const qs = this.queryString({ access_key: this.options.accessKey })
-    const url = `${this.options.apiUrl}/certificates/${id}?${qs}`
-    const postFn = superagent.delete(url)
-    const result = await this.performRequest(postFn)
-
-    return result.body.success === 1
-  }
-
   // Validate Certificate Signing Request
   public async validateCSR(csr: string): Promise<CertificateSigningRequestValidationResult> {
     const qs = this.queryString({ access_key: this.options.accessKey })

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "main": "dist/lib/index.js",
   "scripts": {
     "build": "tsc",
-    "lint": "eslint --ext .ts src",
-    "lint:fix": "eslint --fix --ext .ts src",
+    "lint": "eslint --ext .ts lib",
+    "lint:fix": "eslint --fix --ext .ts lib",
     "prebuild": "rm -r dist",
     "prepublishOnly": "npm run build",
     "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'tests/unit/*.ts'",

--- a/tests/integration/revokeCertificate.test.ts
+++ b/tests/integration/revokeCertificate.test.ts
@@ -1,0 +1,31 @@
+// Copyright 2022 Alisson Acioli <alissonacioli@hotmail.com>
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import { ZeroSSL } from '../../lib'
+import dotenv from 'dotenv'
+import { expect } from 'chai'
+
+const certificateId = ''
+
+describe('Revoke Certificate', function () {
+  dotenv.config()
+  this.timeout(30000)
+
+  // Initialize ZeroSSL
+  const accessKey = process.env.ZEROSSL_ACCESS_KEY || ''
+  const zerossl = new ZeroSSL({ accessKey })
+  expect(zerossl.options.apiUrl).to.equal('api.zerossl.com')
+  expect(zerossl.options.accessKey).to.equal(accessKey)
+
+  it('should revoke a certificate', async () => {
+    // Revoke the certificate
+    const success = await zerossl.revokeCertificate(certificateId)
+    expect(success).to.equal(true)
+
+    // Revoke the certificate
+    // const success = await zerossl.revokeCertificate(certificate.id)
+    // expect(success).to.equal(true)
+  })
+})


### PR DESCRIPTION
ZeroSSL has undergone some changes recently that could affect the perfect functioning of the API, both in the functional part and in the perception and analysis of the client. Due to these changes, I suggest as per my commits that the following changes take effect in your repository. These are the changes:

1. Removed delete certificate function
2. Created the revoke certificate function
3. Updated error listing
4. Small tweak to package.json in indicated eslint folder (src to lib)
5. Return of errors in object
6. Creation of the certificate revocation test
7. Updated readme

### **Explanation of removing the delete certificate function**

ZeroSSL had 2 endpoints, one for **CANCEL** certificates and one for **DELETE** certificates. Recently in one of the returns from the old use of the delete certificate endpoint they inform that it no longer makes sense to **DELETE** a certificate but to **CANCEL** the certificate. Once canceled it exits the **"draft"** or **"pending_validation"** listing, thus performing the delete function automatically. This was good for API users, as in the past you had to cancel the certificate and then ask to delete it from the ZeroSSL listing.

### **Explanation of the error return change**

One difficulty I faced when using the old error return is that I needed to identify the type of error that happened in my request but the error returned was in the format **"CODE (TYPE) MESSAGE"** as a string. For me to get only the **TYPE**, I needed a regex or another way to get only the type. This change solves that, where anyone can necessarily get what they need, maybe just the code, just the type, just the message or if you prefer you can assemble the same pattern as before just concatenating the object's parameters.

Hope these changes help.
Hugs,
Alisson Acioli