### PR TITLE
Include HTTP error detail in thrown errors

### DIFF
--- a/dist/lib/errors.d.ts
+++ b/dist/lib/errors.d.ts
@@ -1,4 +1,12 @@
-import { ZeroSSLError } from './types';
+import { ZeroSSLErrorData } from './types';
+export declare class ZeroSSLError extends Error {
+    code: number | undefined;
+    details: import("./types").ZeroSSLErrorDetail | undefined;
+    status: number;
+    type: string | undefined;
+    constructor(status: number, data: ZeroSSLErrorData);
+}
 export declare const ZeroSSLErrorMap: {
-    [key: number]: ZeroSSLError;
+    [key: number]: ZeroSSLErrorData;
 };
+export declare function findZeroSSLError(code: number): ZeroSSLErrorData;

--- a/dist/lib/errors.js
+++ b/dist/lib/errors.js
@@ -1,6 +1,46 @@
 "use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
 exports.__esModule = true;
-exports.ZeroSSLErrorMap = void 0;
+exports.findZeroSSLError = exports.ZeroSSLErrorMap = exports.ZeroSSLError = void 0;
+var ZeroSSLError = (function (_super) {
+    __extends(ZeroSSLError, _super);
+    function ZeroSSLError(status, data) {
+        var _this = _super.call(this, data.message) || this;
+        _this.name = 'ZeroSSLError';
+        _this.status = status;
+        _this.code = data.code;
+        _this.details = data.details;
+        _this.type = data.type;
+        return _this;
+    }
+    return ZeroSSLError;
+}(Error));
+exports.ZeroSSLError = ZeroSSLError;
 exports.ZeroSSLErrorMap = {
     0: {
         code: 0,
@@ -243,3 +283,10 @@ exports.ZeroSSLErrorMap = {
         message: 'Error retrieveing domain verification status. Try again and make sure Email Verification is selected.'
     }
 };
+function findZeroSSLError(code) {
+    if (exports.ZeroSSLErrorMap[code] !== undefined) {
+        return __assign({}, exports.ZeroSSLErrorMap[code]);
+    }
+    return {};
+}
+exports.findZeroSSLError = findZeroSSLError;

--- a/dist/lib/index.d.ts
+++ b/dist/lib/index.d.ts
@@ -1,1 +1,3 @@
 export { ZeroSSL } from './zerossl';
+export { ZeroSSLError } from './errors';
+export type { ZeroSSLErrorDetail, ZeroSSLVerifyDomainsCNAMEErrorDetail, ZeroSSLVerifyDomainsHTTPFileUploadErrorDetail } from './types';

--- a/dist/lib/index.js
+++ b/dist/lib/index.js
@@ -1,12 +1,18 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
 }));
 exports.__esModule = true;
-exports.ZeroSSL = void 0;
+exports.ZeroSSLError = exports.ZeroSSL = void 0;
 var zerossl_1 = require("./zerossl");
 __createBinding(exports, zerossl_1, "ZeroSSL");
+var errors_1 = require("./errors");
+__createBinding(exports, errors_1, "ZeroSSLError");

--- a/dist/lib/types.d.ts
+++ b/dist/lib/types.d.ts
@@ -1,15 +1,15 @@
-export declare type Certificate = {
+export type Certificate = {
     'certificate.crt': string;
     'ca_bundle.crt': string;
 };
-export declare type CertificateList = {
+export type CertificateList = {
     total_count: number;
     result_count: number;
     page: number;
     limit: number;
     results: CertificateRecord[];
 };
-export declare type CertificateRecord = {
+export type CertificateRecord = {
     id: string;
     type: string;
     common_name: string;
@@ -35,7 +35,7 @@ export declare type CertificateRecord = {
         };
     };
 };
-export declare type CertificateSigningRequestOptions = {
+export type CertificateSigningRequestOptions = {
     country: string;
     state: string;
     locality: string;
@@ -44,27 +44,27 @@ export declare type CertificateSigningRequestOptions = {
     email?: string;
     commonName: string;
 };
-export declare type CertificateSigningRequestValidationResult = {
+export type CertificateSigningRequestValidationResult = {
     valid: boolean;
-    error?: ZeroSSLError;
+    error?: ZeroSSLErrorData;
 };
-export declare type CreateCertificateOptions = {
+export type CreateCertificateOptions = {
     csr: string;
     domains: string[];
     validityDays: 90 | 365;
     strictDomains: boolean;
 };
-export declare type KeyPair = {
+export type KeyPair = {
     publicKey: string;
     privateKey: string;
 };
-export declare type ListCertificateOptions = {
+export type ListCertificateOptions = {
     page?: number;
     limit?: number;
     search?: string;
     certificate_status?: 'draft' | 'pending_validation' | 'issued' | 'cancelled' | 'expiring_soon' | 'expire';
 };
-export declare type VerificationStatus = {
+export type VerificationStatus = {
     validation_completed: number;
     details: {
         [domain: string]: {
@@ -73,27 +73,42 @@ export declare type VerificationStatus = {
         };
     };
 };
-export declare type VerifyDomainOptions = {
+export type VerifyDomainOptions = {
     validation_method: 'EMAIL' | 'CNAME_CSR_HASH' | 'HTTP_CSR_HASH' | 'HTTPS_CSR_HASH';
     validation_email?: string;
 };
-export declare type ZeroSSLOptions = {
+export type ZeroSSLOptions = {
     accessKey: string;
     apiUrl?: string;
 };
-export declare type ZeroSSLError = {
+export type ZeroSSLErrorData = {
     code?: number;
     type?: string;
     message?: string;
-    details?: {
+    details?: ZeroSSLErrorDetail;
+};
+export type ZeroSSLErrorDetail = ZeroSSLVerifyDomainsCNAMEErrorDetail | ZeroSSLVerifyDomainsHTTPFileUploadErrorDetail;
+export type ZeroSSLVerifyDomainsCNAMEErrorDetail = {
+    [domain: string]: {
         [domain: string]: {
-            [domain: string]: {
-                cname_found: number;
-                record_correct: number;
-                target_host: string;
-                target_record: string;
-                actual_record: string;
-            };
+            cname_found: number;
+            record_correct: number;
+            target_host: string;
+            target_record: string;
+            actual_record: string;
+        };
+    };
+};
+export type ZeroSSLVerifyDomainsHTTPFileUploadErrorDetail = {
+    [domain: string]: {
+        [path: string]: {
+            validation_successful: false | undefined;
+            file_found: number;
+            error: boolean;
+            error_slug: string;
+            error_info: string;
+        } | {
+            validation_successful: true;
         };
     };
 };

--- a/dist/lib/zerossl.js
+++ b/dist/lib/zerossl.js
@@ -25,7 +25,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     function verb(n) { return function (v) { return step([n, v]); }; }
     function step(op) {
         if (f) throw new TypeError("Generator is already executing.");
-        while (_) try {
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
             if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
             if (y = 0, t) op = [op[0] & 2, t.value];
             switch (op[0]) {
@@ -51,8 +51,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 exports.__esModule = true;
 exports.ZeroSSL = void 0;
-var errors_1 = require("./errors");
 var node_forge_1 = __importDefault(require("node-forge"));
+var errors_1 = require("./errors");
 var superagent_1 = __importDefault(require("superagent"));
 var defaultOptions = {
     apiUrl: 'api.zerossl.com'
@@ -65,22 +65,19 @@ var ZeroSSL = (function () {
         return Object.keys(params).map(function (key) { return "".concat(key, "=").concat(params[key]); }).join('&');
     };
     ZeroSSL.prototype.performRequest = function (request) {
+        var _a, _b;
         return __awaiter(this, void 0, void 0, function () {
-            var response, errorCode, error;
-            return __generator(this, function (_a) {
-                switch (_a.label) {
+            var response, error;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
                     case 0: return [4, request];
                     case 1:
-                        response = _a.sent();
+                        response = _c.sent();
                         if (response.status !== 200 || response.body.success === false) {
-                            errorCode = response.body.error.code || 0;
-                            error = errors_1.ZeroSSLErrorMap[errorCode];
-                            throw ({
-                                message: error.message,
-                                code: error.code,
-                                type: error.type,
-                                status: response.status
-                            });
+                            error = (0, errors_1.findZeroSSLError)(((_a = response.body.error) === null || _a === void 0 ? void 0 : _a.code) || 0);
+                            if ((_b = response.body.error) === null || _b === void 0 ? void 0 : _b.details)
+                                error.details = response.body.error.details;
+                            throw new errors_1.ZeroSSLError(response.status, error);
                         }
                         return [2, response];
                 }

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -55,9 +55,23 @@
 // 2837 failed_resending_email  Internal error resending verification email. Try again or contact support.
 // 2838 failed_getting_validation_status  Error retrieveing domain verification status. Try again and make sure Email Verification is selected.
 
-import { ZeroSSLError } from './types'
+import { ZeroSSLErrorData } from './types'
 
-export const ZeroSSLErrorMap: { [key: number]: ZeroSSLError } = {
+export class ZeroSSLError extends Error {
+  public code
+  public details
+  public status
+
+  constructor(status: number, data: ZeroSSLErrorData) {
+    super(data.message)
+    this.name = 'ZeroSSLError'
+    this.status = status
+    this.code = data.code
+    this.details = data.details
+  }
+}
+
+export const ZeroSSLErrorMap: { [key: number]: ZeroSSLErrorData } = {
   //
   // Errors - Undocumented
   0: {
@@ -334,4 +348,15 @@ export const ZeroSSLErrorMap: { [key: number]: ZeroSSLError } = {
     type: 'failed_getting_validation_status',
     message: 'Error retrieveing domain verification status. Try again and make sure Email Verification is selected.'
   }
+}
+
+/**
+ * Find a ZeroSSL error by code.
+ * Returns a copy of the error, or if it is not found, an empty object.
+ */
+export function findZeroSSLError(code: number): ZeroSSLErrorData {
+  if (ZeroSSLErrorMap[code] !== undefined) {
+    return { ...ZeroSSLErrorMap[code] }
+  }
+  return {}
 }

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -61,6 +61,7 @@ export class ZeroSSLError extends Error {
   public code
   public details
   public status
+  public type
 
   constructor(status: number, data: ZeroSSLErrorData) {
     super(data.message)
@@ -68,6 +69,7 @@ export class ZeroSSLError extends Error {
     this.status = status
     this.code = data.code
     this.details = data.details
+    this.type = data.type
   }
 }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,3 +4,9 @@
 // https://opensource.org/licenses/MIT.
 
 export { ZeroSSL } from './zerossl'
+export { ZeroSSLError } from './errors'
+export type {
+  ZeroSSLErrorDetail,
+  ZeroSSLVerifyDomainsCNAMEErrorDetail,
+  ZeroSSLVerifyDomainsHTTPFileUploadErrorDetail
+} from './types'

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -55,7 +55,7 @@ export type CertificateSigningRequestOptions = {
 
 export type CertificateSigningRequestValidationResult = {
   valid: boolean
-  error?: ZeroSSLError
+  error?: ZeroSSLErrorData
 }
 
 export type CreateCertificateOptions = {
@@ -97,19 +97,37 @@ export type ZeroSSLOptions = {
   apiUrl?: string
 }
 
-export type ZeroSSLError = {
+export type ZeroSSLErrorData = {
   code?: number
   type?: string
   message?: string
-  details?: {
+  details?: ZeroSSLErrorDetail
+}
+
+export type ZeroSSLErrorDetail = ZeroSSLVerifyDomainsCNAMEErrorDetail | ZeroSSLVerifyDomainsHTTPFileUploadErrorDetail
+
+export type ZeroSSLVerifyDomainsCNAMEErrorDetail = {
+  [domain: string]: {
     [domain: string]: {
-      [domain: string]: {
-        cname_found: number
-        record_correct: number
-        target_host: string
-        target_record: string
-        actual_record: string
-      }
+      cname_found: number
+      record_correct: number
+      target_host: string
+      target_record: string
+      actual_record: string
+    }
+  }
+}
+
+export type ZeroSSLVerifyDomainsHTTPFileUploadErrorDetail = {
+  [domain: string]: {
+    [domain: string]: {
+      validation_successful: false | undefined
+      file_found: number
+      error: boolean
+      error_slug: string
+      error_info: string
+    } | {
+      validation_successful: true
     }
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -120,7 +120,7 @@ export type ZeroSSLVerifyDomainsCNAMEErrorDetail = {
 
 export type ZeroSSLVerifyDomainsHTTPFileUploadErrorDetail = {
   [domain: string]: {
-    [domain: string]: {
+    [path: string]: {
       validation_successful: false | undefined
       file_found: number
       error: boolean


### PR DESCRIPTION
The current lib - specifically, the `performRequest()` function - is limited in that it strips some data when throwing an error to the caller. For example, when [verifying domains](https://zerossl.com/documentation/api/verify-domains/) the data in `error.details` is discarded, which might otherwise be useful for diagnosing blockers for certificate issuance.

This PR adds capture of `error.details` with types allowing the caller to cast it for local reporting.

This PR also substitutes a `class ZeroSSLError extends Error` for the original `type ZeroSSLError`. While throwing an object is allowed by JS, this is more conventional and `Error.name` can be used to disambiguate the error type.